### PR TITLE
Add method for creating a custom api call, similar to how APIMate does it

### DIFF
--- a/lib/administration.js
+++ b/lib/administration.js
@@ -39,6 +39,10 @@ function administration(host, salt) {
 			}
 
 			return util.GETAction(this.host, this.salt, "end", qparams);
+		},
+		customCall: function(callName, params) {
+
+			return util.GETAction(this.host, this.salt, callName, params);
 		}
 	}
 	


### PR DESCRIPTION
This way integrations can implement their custom methods without needing changes into the bbb-promise lib.